### PR TITLE
Make the stringify optional

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,16 +7,17 @@ requested. :sparkles:
 
 ## Discuss the changes before doing them
  - First of all, open an issue in the repository, using the [bug tracker][1],
-   describing the contribution you'd like to make, the bug you found or any
+   describing the contribution you would like to make, the bug you found or any
    other ideas you have. This will help us to get you started on the right
    foot.
 
  - If it makes sense, add the platform and software information (e.g. operating
-   system, Node.JS version etc), screenshots (so we can see what you're seeing).
+   system, Node.JS version etc.), screenshots (so we can see what you are
+   seeing).
 
- - It's recommended to wait for feedback before continuing to next steps. However,
-   if the issue is clear (e.g. a typo) and the fix is simple, you can continue
-   and fix it.
+ - It is recommended to wait for feedback before continuing to next steps.
+   However, if the issue is clear (e.g. a typo) and the fix is simple, you can
+   continue and fix it.
 
 ## Fixing issues
  - Fork the project in your account and create a branch with your fix:
@@ -26,13 +27,14 @@ requested. :sparkles:
    [code style][2]. If the project contains tests (generally, the `test`
    directory), you are encouraged to add a test as well. :memo:
 
- - If the project contains a `package.json` file add yourself in the
-   `contributors` array (if it doesn't exist, create it):
+ - If the project contains a `package.json` or a `bower.json` file add yourself
+   in the `contributors` array (or `authors` in the case of `bower.json`;
+   if the array does not exist, create it):
 
    ```json
    {
       "contributors": [
-         "Your Name <and@email.address> (http://your.website)
+         "Your Name <and@email.address> (http://your.website)"
       ]
    }
    ```
@@ -40,11 +42,11 @@ requested. :sparkles:
 ## Creating a pull request
 
  - Open a pull request, and reference the initial issue in the pull request
-   message (e.g. *fixes #<your-issue-number*). Write a good description and
+   message (e.g. *fixes #<your-issue-number>*). Write a good description and
    title, so everybody will know what is fixed/improved.
 
- - If it makes sense, add screenshots, gifs etc, so it's easier to see what's
-   going on.
+ - If it makes sense, add screenshots, gifs etc., so it is easier to see what
+   is going on.
 
 ## Wait for feedback
 Before accepting your contributions, we will review them. You may get feedback
@@ -53,8 +55,10 @@ in your branch and the pull request will be updated automatically.
 
 ## Everyone is happy!
 Finally, your contributions will be merged, and everyone will be happy! :smile:
+Contributions are more than welcome!
 
 Thanks! :sweat_smile:
 
 [1]: https://github.com/IonicaBizau/node-oargv/issues
+
 [2]: https://github.com/IonicaBizau/code-style

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 The KINDLY License
-Copyright (c) 2015 Ionică Bizău <bizauionica@yahoo.com>
+Copyright (c) 2015 Ionică Bizău <bizauionica@gmail.com>
 
 You have the permission to use this software, read its source code, modify and
 redistribute it under the following terms:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <!-- * * * Thanks! * * *                                                    -->
 <!---------------------------------------------------------------------------->
 
-![oargv](http://i.imgur.com/TgmKSGy.png)
+[![oargv](http://i.imgur.com/TgmKSGy.png)](#)
 
 # oargv [![Donate now][donate-now]][paypal-donations]
 
@@ -34,50 +34,53 @@ var OArgv = require("oargv");
 console.log(OArgv({
     r: true
   , _: ["target.zip", "somedir"]
-}, "zip"));
-// => zip -r "target.zip" "somedir"
+}, "zip", true));
+// => zip "-r" "target.zip" "somedir"
 
 console.log(OArgv({
     d: "http://ionicabizau.net"
   , tt: true
   , size: "600x800"
-}, "bat"));
-// => bat -d "http://ionicabizau.net" --tt --size "600x800"
+}, "bat", true));
+// => bat "-d" "http://ionicabizau.net" "--tt" "--size" "600x800"
 
 console.log(OArgv({
     escaping: "She said: \"Hello World\"!"
-}, "foo"));
-// => foo --escaping "She said: \"Hello World\"!"
+}, "foo", true));
+// => foo "--escaping" "She said: \"Hello World\"!"
 
 console.log(OArgv({
-    noCommand: "foo",
-    b: true
+    noCommand: "foo"
+  , b: true
 }));
-// => --noCommand "foo" -b
+// => [ '--noCommand', 'foo', '-b' ]
 
 console.log(OArgv({
     __: "=",
     custom: "Separator"
 }, "foo"));
-// => foo --custom="Separator"
-
+// => [ '--custom="Separator"' ]
 ```
 
 ## Documentation
 
-### `OArgv(options, prgm)`
+### `OArgv(options, prgm, stringify)`
 Stringifies the options, building a command.
 
 #### Params
 - **Object** `options`: The options that should be stringified. If it contains the `_` field, then this should be an `Array` of strings, that representing values
 that will be added at the end of the command. The `__` field is the separator (default: `" "`).
 - **String** `prgm`: The program that executes the command (default: `""`).
+- **Boolean** `stringify`: If `true`, the result array will be stringified (default: `false`).
 
 #### Return
-- **String** The stringified arguments.
+- **String|Array** The stringified arguments (if `stringify` is `true`) or the array of arguments.
 
 ## How to contribute
 Have an idea? Found a bug? See [how to contribute][contributing].
+
+## Who uses this
+If you are using this library in one of your projects, add it in this list. :sparkles:
 
 ## License
 [KINDLY][license] © [Ionică Bizău][website]–The [LICENSE](/LICENSE) file contains
@@ -88,4 +91,4 @@ a copy of the license.
 [website]: http://ionicabizau.net
 [docs]: /DOCUMENTATION.md
 [paypal-donations]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=MG98D7NPFZ3MG
-[donate-now]: http://i.imgur.com/jioicaN.png
+[donate-now]: http://i.imgur.com/6cMbHOC.png

--- a/example/index.js
+++ b/example/index.js
@@ -4,32 +4,32 @@ var OArgv = require("../lib");
 console.log(OArgv({
     r: true
   , _: ["target.zip", "somedir"]
-}, "zip"));
-// => zip -r "target.zip" "somedir"
+}, "zip", true));
+// => zip "-r" "target.zip" "somedir"
 
 
 console.log(OArgv({
     d: "http://ionicabizau.net"
   , tt: true
   , size: "600x800"
-}, "bat"));
-// => bat -d "http://ionicabizau.net" --tt --size "600x800"
+}, "bat", true));
+// => bat "-d" "http://ionicabizau.net" "--tt" "--size" "600x800"
 
 
 console.log(OArgv({
     escaping: "She said: \"Hello World\"!"
-}, "foo"));
-// => foo --escaping "She said: \"Hello World\"!"
+}, "foo", true));
+// => foo "--escaping" "She said: \"Hello World\"!"
 
 
 console.log(OArgv({
-    noCommand: "foo",
-    b: true
+    noCommand: "foo"
+  , b: true
 }));
-// => --noCommand "foo" -b
+// => [ '--noCommand', 'foo', '-b' ]
 
 console.log(OArgv({
     __: "=",
     custom: "Separator"
 }, "foo"));
-// => foo --custom="Separator"
+// => [ '--custom="Separator"' ]

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,7 @@
 // Dependencies
-var Ul = require("ul");
+var Ul = require("ul")
+  , IterateObject = require("iterate-object")
+  ;
 
 /**
  * OArgv
@@ -11,12 +13,13 @@ var Ul = require("ul");
  * the `_` field, then this should be an `Array` of strings, that representing values
  * that will be added at the end of the command. The `__` field is the separator (default: `" "`).
  * @param {String} prgm The program that executes the command (default: `""`).
- * @return {String} The stringified arguments.
+ * @param {Boolean} stringify If `true`, the result array will be stringified (default: `false`).
+ * @return {String|Array} The stringified arguments (if `stringify` is `true`) or the array of arguments.
  */
-var OArgv = module.exports = function (options, prgm) {
+var OArgv = module.exports = function (options, prgm, stringify) {
 
     // Variables
-    var sOpts = ""
+    var sOpts = []
       , c = null
       , escape = JSON.stringify
       ;
@@ -33,25 +36,32 @@ var OArgv = module.exports = function (options, prgm) {
     }
 
     // Options
-    Object.keys(options).forEach(function (k) {
+    IterateObject(options, function (c, k) {
         if (k === "_" || k === "__") { return; }
-        c = options[k];
-
-        if (k.length === 1) {
-            sOpts += " -" + k;
-        } else {
-            sOpts += " --" + k;
-        }
-
+        var cArg = (k.length === 1 ? "-" : "--") + k;
         if (typeof c === "string") {
-            sOpts += options.__ + escape(c);
+            if (options.__ !== " ") {
+                cArg += options.__ + escape(c);
+                sOpts.push(cArg);
+            } else {
+                sOpts.push(cArg, c);
+            }
+        } else {
+            sOpts.push(cArg);
         }
     });
 
-    // Build everything
-    return (prgm + sOpts + options._.map(function (c) {
-        return " " + escape(c);
-    }).join("")).trim();
+
+    if (stringify) {
+        return prgm + " " + sOpts.map(function (c) {
+            return escape(c);
+        }).join(" ") + " " + options._.map(function (c) {
+            return escape(c);
+        }).join(" ").trim();
+    } else {
+        sOpts = sOpts.concat(options._);
+        return sOpts;
+    }
 };
 
 // Defaults

--- a/lib/index.js
+++ b/lib/index.js
@@ -53,11 +53,11 @@ var OArgv = module.exports = function (options, prgm, stringify) {
 
 
     if (stringify) {
-        return prgm + " " + sOpts.map(function (c) {
+        return (prgm ? prgm + " " : "") + sOpts.map(function (c) {
             return escape(c);
-        }).join(" ") + " " + options._.map(function (c) {
+        }).join(" ") + (options._.length ? " " + options._.map(function (c) {
             return escape(c);
-        }).join(" ").trim();
+        }).join(" ") : "");
     } else {
         sOpts = sOpts.concat(options._);
         return sOpts;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:IonicaBizau/node-oargv.git"
+    "url": "git+ssh://git@github.com/IonicaBizau/node-oargv.git"
   },
   "keywords": [
     "oargv",
@@ -20,9 +20,6 @@
     "commands",
     "bash"
   ],
-  "dependencies": {
-    "ul": "5.0.0"
-  },
   "author": "Ionică Bizău <bizauionica@gmail.com>",
   "license": "KINDLY",
   "bugs": {
@@ -34,5 +31,9 @@
   },
   "blah": {
     "h_img": "http://i.imgur.com/TgmKSGy.png"
+  },
+  "dependencies": {
+    "iterate-object": "^1.1.0",
+    "ul": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oargv",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Turns an object into a bash command.",
   "main": "lib/index.js",
   "directories": {

--- a/test/index.js
+++ b/test/index.js
@@ -3,42 +3,42 @@ var OArgv = require("../lib")
   , Assert = require("assert")
   ;
 
-it("should support commands and args", function (cb) {
+it("should support commands and args and stringify the result", function (cb) {
     Assert.equal(OArgv({
         r: true
       , _: ["target.zip", "somedir"]
-    }, "zip"), "zip -r \"target.zip\" \"somedir\"");
+    }, "zip", true), "zip \"-r\" \"target.zip\" \"somedir\"");
     cb();
 });
 
-it("should support boolean args", function (cb) {
+it("should support boolean args and stringify the result", function (cb) {
     Assert.equal(OArgv({
         d: "http://ionicabizau.net"
       , tt: true
       , size: "600x800"
-    }, "bat"), "bat -d \"http://ionicabizau.net\" --tt --size \"600x800\"");
+    }, "bat", true), "bat \"-d\" \"http://ionicabizau.net\" \"--tt\" \"--size\" \"600x800\"");
     cb();
 });
 
 it("should escape arguments", function (cb) {
     Assert.equal(OArgv({
         escaping: "She said: \"Hello World\"!"
-    }, "foo"), "foo --escaping \"She said: \\\"Hello World\\\"!\"");
+    }, "foo", true), "foo \"--escaping\" \"She said: \\\"Hello World\\\"!\"");
     cb();
 });
 
 it("should work without commands", function (cb) {
-    Assert.equal(OArgv({
+    Assert.deepEqual(OArgv({
         noCommand: "foo",
         b: true
-    }), "--noCommand \"foo\" -b");
+    }), ["--noCommand", "foo", "-b"]);
     cb();
 });
 
 it("should support custom separators", function (cb) {
-    Assert.equal(OArgv({
+    Assert.deepEqual(OArgv({
         __: "=",
         custom: "Separator"
-    }, "foo"), "foo --custom=\"Separator\"")
+    }), ["--custom=\"Separator\""])
     cb();
 });


### PR DESCRIPTION
Since it's a common way to spawn processes instead of executing them, it would probably handy to have the raw options array and use it in the spawn call.

Now, by default, the function returns an array of strings like mentioned above. :star2:
